### PR TITLE
Inference hex decomposition for large images--WIP

### DIFF
--- a/tensorflow/cc/inference.cpp
+++ b/tensorflow/cc/inference.cpp
@@ -704,7 +704,7 @@ int main(int argc, char *argv[]) {
   bool do_hexes = true;
 //  float overlap_fraction = 1.1;
   int overlap_pixels = 32;
-  bool use_gpu = false;
+  bool use_gpu = true;
 
   // data structures to hold multiple image and result names in sequence order
   std::vector<std::string> bulk_images {};
@@ -736,7 +736,7 @@ int main(int argc, char *argv[]) {
     Flag("do_quads", &do_quads, "do quad breakdown in addition to squaring up--default is true"),
     Flag("do_hexes", &do_hexes, "do hex breakdown in addition to quads and squaring up--default is true"),
     // TODO dwh: we could set this to an integer to indicate which gpu to use if there are more than one and -1 to disable??
-    Flag("use_gpu", &use_gpu, "use gpu--default is false"),
+    Flag("use_gpu", &use_gpu, "use gpu if one is available--default is true"),
   };
   string usage = tensorflow::Flags::Usage(argv[0], flag_list);
   const bool parse_result = tensorflow::Flags::Parse(&argc, argv, flag_list);
@@ -863,7 +863,7 @@ int main(int argc, char *argv[]) {
         }
 
         // Determine if we want to do another layer of decomposition
-        if (do_hexes && static_cast<float>(quad_image_height) > 1.5 * static_cast<float>(input_height)) {
+        if (do_hexes && static_cast<float>(quad_image_height) > 1.4 * static_cast<float>(input_height)) {
           // Make another subimage vector for hex images and populate it
           hex_image_height = overlap_pixels + (quad_image_height / 2);
           // TODO: is the aspect ratio valid here?

--- a/tensorflow/cc/inference.cpp
+++ b/tensorflow/cc/inference.cpp
@@ -1005,7 +1005,8 @@ int main(int argc, char *argv[]) {
       std::cout << "Model hex results resized to " << (resized_hex_outputs[0]).shape() << " for sub merging" << std::endl;
       output_classes = uint(hex_output.shape().dim_size(3));
 
-      // Merge the above 32 hex images into 8 arrays of sub images that can be added later
+      // Merge the above 32 (4 hexes * 4 quads * 2 subs) hex images into 8 (4 quads * 2 subs) arrays of sub images that can be added later
+      // (Or 16 (4 hexes * 4 quads * 1 subs) into 4 (4 quads * 1 subs) arrays)
       auto float_output_hex_array = static_cast<float *>(resized_hex_outputs[0].flat<float>().data());
 
       for (int hquad = 0; hquad < quad_images.size(); ++hquad) {
@@ -1092,11 +1093,13 @@ int main(int argc, char *argv[]) {
             output_classes);
       }
 
+      // Merge the above 8 (4 quads * 2 subs) into 2 (2 sub-images) arrays that can be added later
+      // (Or 4 (4 quads * 1 subs) into 1 (sub-images) arrays)
       for (int iquad = 0; iquad < sub_images.size(); ++iquad) {
         int sub_offset = iquad * 4;
         std::cout << "Merging four quads into quad sub-image " << iquad << std::endl;
 
-      // now have 8 dimensional array of size quad_image_height x quad_image_width x num_classes
+      // now have 4x dimensional array of size quad_image_height x quad_image_width x num_classes
       // ((0 hz 1) vt (2 hz 3)) hz ((4 hz 5) vt (6 hz 7))
       // (  top    vt  bottom ) hz (  top    vt  bottom )
       //         left           hz           right
@@ -1183,7 +1186,7 @@ int main(int argc, char *argv[]) {
 
     switch (sub_images.size()) {
       case 2: {
-        std::cout << "Merging 2 output sub-images" << std::endl;
+        std::cout << "Merging two output sub-images" << std::endl;
         merged_output_classes = hive_segmentation::hz_merge(
             float_output_array,
             0,
@@ -1196,14 +1199,14 @@ int main(int argc, char *argv[]) {
         break;
       }
       case 1: {
-        std::cout << "Single output image" << std::endl;
+        std::cout << "Using single output sub-image" << std::endl;
         merged_output_classes.reserve(image_height * image_width * output_classes);
         for (std::size_t ival = 0; ival < (image_height * image_width * output_classes); ++ival) {
           merged_output_classes.emplace_back(float_output_array[ival]);
         }
         break;
       }
-      default:  LOG(ERROR) << "Error: Invalid number of sub-images: " << sub_images.size();
+      default: LOG(ERROR) << "Error: Invalid number of sub-images: " << sub_images.size();
         return -1;
     }
 

--- a/tensorflow/cc/inference.cpp
+++ b/tensorflow/cc/inference.cpp
@@ -548,9 +548,8 @@ void add_images(const std::vector<float> &first_image,
   for (auto i = 0; i < num_x; i++) {
     for (auto j = 0; j < num_y; j++) {
       for (auto s = 0; s < num_classes; s++) {
-        float segmentation_value = 0.f;
         // use both sub images in equal proportion
-        segmentation_value = 0.5f * first_image[((i * num_y + j) * num_classes) + s];
+        float segmentation_value = 0.5f * first_image[((i * num_y + j) * num_classes) + s];
         segmentation_value += 0.5f * second_image[((i * num_y + j) * num_classes) + s];
         merged_output.emplace_back(segmentation_value);
       }

--- a/tensorflow/cc/inference.cpp
+++ b/tensorflow/cc/inference.cpp
@@ -940,9 +940,9 @@ int main(int argc, char *argv[]) {
       // resize and normalize input by mean and std
       std::cout << "Resizing and Normalizing quad input tensor" << std::endl;
       Status resized_normalize_quad_status = ::hive_segmentation::NormalizeTensor(quad_tensor,
-                                                                             &resized_normal_quad_tensors,
-                                                                             input_height,
-                                                                             input_width); //, input_mean, input_std);
+                                                                                  &resized_normal_quad_tensors,
+                                                                                  input_height,
+                                                                                  input_width); //, input_mean, input_std);
       if (!resized_normalize_quad_status.ok()) {
         LOG(ERROR) << "Error: Input quad tensor normalization failed: " << resized_normalize_quad_status;
         return -1;
@@ -1013,34 +1013,31 @@ int main(int argc, char *argv[]) {
         int sub_offset = hquad * 4;
         std::cout << "Merging four hexes into hex quad " << hquad << std::endl;
 //        std::cout << "Running hex " << hquad << " with offset " << sub_offset << " and size " << hex_image_height * quad_image_width * output_classes << std::endl;
-        auto merged_top_quad = hive_segmentation::hz_merge(
-            float_output_hex_array,
-            sub_offset + 0,
-            sub_offset + 1,
-            hex_image_height,
-            hex_image_width,
-            output_classes,
-            hex_image_height,
-            quad_image_width);
+        auto merged_top_quad = hive_segmentation::hz_merge(float_output_hex_array,
+                                                           sub_offset + 0,
+                                                           sub_offset + 1,
+                                                           hex_image_height,
+                                                           hex_image_width,
+                                                           output_classes,
+                                                           hex_image_height,
+                                                           quad_image_width);
 
-        auto merged_bottom_quad = hive_segmentation::hz_merge(
-            float_output_hex_array,
-            sub_offset + 2,
-            sub_offset + 3,
-            hex_image_height,
-            hex_image_width,
-            output_classes,
-            hex_image_height,
-            quad_image_width);
+        auto merged_bottom_quad = hive_segmentation::hz_merge(float_output_hex_array,
+                                                              sub_offset + 2,
+                                                              sub_offset + 3,
+                                                              hex_image_height,
+                                                              hex_image_width,
+                                                              output_classes,
+                                                              hex_image_height,
+                                                              quad_image_width);
 
-        auto hex_quad = hive_segmentation::vert_merge(
-            merged_top_quad,
-            merged_bottom_quad,
-            hex_image_height,
-            quad_image_width,
-            output_classes,
-            quad_image_height,
-            quad_image_width);
+        auto hex_quad = hive_segmentation::vert_merge(merged_top_quad,
+                                                      merged_bottom_quad,
+                                                      hex_image_height,
+                                                      quad_image_width,
+                                                      output_classes,
+                                                      quad_image_height,
+                                                      quad_image_width);
 
         hex_quads.emplace_back(hex_quad);
       }
@@ -1064,18 +1061,17 @@ int main(int argc, char *argv[]) {
         return -1;
       }
       auto const &quad_output = quad_outputs[0];
-      output_classes = uint(quad_output.shape().dim_size(3));
+      output_classes = static_cast<uint>(quad_output.shape().dim_size(3));
       std::cout << "Quad output shape is " << quad_output.shape() << " with " << quad_output.shape().dims() << " dimensions and " << output_classes << " classes" << std::endl;
 
 
       // resize and merge hexes if available to get quad output sized images
-      Status resize_quad_status;
       std::vector<Tensor> resized_quad_outputs {};
       resized_quad_outputs.reserve(quad_image_height * quad_image_width * output_classes);
       std::vector<Tensor> quad_outputs {};
       quad_outputs.reserve(quad_image_height * quad_image_width * output_classes);
 
-      resize_quad_status = ::hive_segmentation::ResizeTensor(quad_output, &resized_quad_outputs, quad_image_height, quad_image_width);
+      Status resize_quad_status = ::hive_segmentation::ResizeTensor(quad_output, &resized_quad_outputs, quad_image_height, quad_image_width);
       if (!resize_quad_status.ok()) {
         LOG(ERROR) << "Error: Resizing quad output from model failed: " << resize_quad_status;
         return -1;
@@ -1085,12 +1081,12 @@ int main(int argc, char *argv[]) {
 
       for (std::size_t ihex = 0; ihex < hex_quads.size(); ++ihex) {
         std::cout << "Adding hex-quad " << ihex << " to sub-images" << std::endl;
-        hive_segmentation::add_images(
-            hex_quads[ihex],
-            &(float_output_quad_array[static_cast<int>(ihex) * quad_image_height * quad_image_width * output_classes]),
-            quad_image_height,
-            quad_image_width,
-            output_classes);
+        hive_segmentation::add_images(hex_quads[ihex],
+                                      &(float_output_quad_array[static_cast<int>(ihex) * quad_image_height
+                                          * quad_image_width * output_classes]),
+                                      quad_image_height,
+                                      quad_image_width,
+                                      output_classes);
       }
 
       // Merge the above 8 (4 quads * 2 subs) into 2 (2 sub-images) arrays that can be added later
@@ -1104,34 +1100,31 @@ int main(int argc, char *argv[]) {
       // (  top    vt  bottom ) hz (  top    vt  bottom )
       //         left           hz           right
 
-      auto merged_top_quad = hive_segmentation::hz_merge(
-          float_output_quad_array,
-          sub_offset + 0,
-          sub_offset + 1,
-          quad_image_height,
-          quad_image_width,
-          output_classes,
-          quad_image_height,
-          leftImage.cols);
+      auto merged_top_quad = hive_segmentation::hz_merge(float_output_quad_array,
+                                                         sub_offset + 0,
+                                                         sub_offset + 1,
+                                                         quad_image_height,
+                                                         quad_image_width,
+                                                         output_classes,
+                                                         quad_image_height,
+                                                         leftImage.cols);
 
-      auto merged_bottom_quad = hive_segmentation::hz_merge(
-          float_output_quad_array,
-          sub_offset + 2,
-          sub_offset + 3,
-          quad_image_height,
-          quad_image_width,
-          output_classes,
-          quad_image_height,
-          leftImage.cols);
+        auto merged_bottom_quad = hive_segmentation::hz_merge(float_output_quad_array,
+                                                              sub_offset + 2,
+                                                              sub_offset + 3,
+                                                              quad_image_height,
+                                                              quad_image_width,
+                                                              output_classes,
+                                                              quad_image_height,
+                                                              leftImage.cols);
 
-      auto merged_quad = hive_segmentation::vert_merge(
-          merged_top_quad,
-          merged_bottom_quad,
-          quad_image_height,
-          leftImage.cols,
-          output_classes,
-          leftImage.rows,
-          leftImage.cols);
+        auto merged_quad = hive_segmentation::vert_merge(merged_top_quad,
+                                                         merged_bottom_quad,
+                                                         quad_image_height,
+                                                         leftImage.cols,
+                                                         output_classes,
+                                                         leftImage.rows,
+                                                         leftImage.cols);
 
         quad_subs.emplace_back(merged_quad);
       }
@@ -1176,26 +1169,25 @@ int main(int argc, char *argv[]) {
 
     for (std::size_t iquad = 0; iquad < quad_subs.size(); ++iquad) {
       std::cout << "Adding quad sub-image " << iquad << " to image" << std::endl;
-      hive_segmentation::add_images(
-          quad_subs[iquad],
-          &(float_output_array[static_cast<int>(iquad) * sub_image_height * sub_image_width * output_classes]),
-          sub_image_height,
-          sub_image_width,
-          output_classes);
+      hive_segmentation::add_images(quad_subs[iquad],
+                                    &(float_output_array[static_cast<int>(iquad) * sub_image_height * sub_image_width
+                                        * output_classes]),
+                                    sub_image_height,
+                                    sub_image_width,
+                                    output_classes);
     }
 
     switch (sub_images.size()) {
       case 2: {
         std::cout << "Merging two output sub-images" << std::endl;
-        merged_output_classes = hive_segmentation::hz_merge(
-            float_output_array,
-            0,
-            1,
-            leftImage.rows,
-            leftImage.cols,
-            output_classes,
-            image_height,
-            image_width);
+        merged_output_classes = hive_segmentation::hz_merge(float_output_array,
+                                                            0,
+                                                            1,
+                                                            leftImage.rows,
+                                                            leftImage.cols,
+                                                            output_classes,
+                                                            image_height,
+                                                            image_width);
         break;
       }
       case 1: {

--- a/tensorflow/cc/inference.cpp
+++ b/tensorflow/cc/inference.cpp
@@ -537,11 +537,10 @@ void add_images(const std::vector<float> &first_image,
   for (auto i = 0; i < num_x; i++) {
     for (auto j = 0; j < num_y; j++) {
       for (auto s = 0; s < num_classes; s++) {
-        float segmentation_value = 0;
+        float segmentation_value = 0.f;
         // use both sub images in equal proportion
         segmentation_value = 0.5f * first_image[((i * num_y + j) * num_classes) + s];
         segmentation_value += 0.5f * second_image[((i * num_y + j) * num_classes) + s];
-//        merged_output[((i * num_y + j) * num_classes) + s] = segmentation_value;
         merged_output.emplace_back(segmentation_value);
       }
     }
@@ -562,15 +561,7 @@ void add_images(const std::vector<float> &first_image,
   for (auto i = 0; i < num_x; i++) {
     for (auto j = 0; j < num_y; j++) {
       for (auto s = 0; s < num_classes; s++) {
-//        float segmentation_value = 0;
-//        // use both sub images in equal proportion
-//        segmentation_value = 0.5f * first_image[((i * num_y + j) * num_classes) + s];
-//        segmentation_value += 0.5f * second_image[((i * num_y + j) * num_classes) + s];
-//        second_image[((i * num_y + j) * num_classes) + s] = segmentation_value;
-//std::cout << "For pixel x=" << i << " y=" << j << " class=" << s << " value=" << std::endl;
-//std::cout << first_image[((i * num_y + j) * num_classes) + s] << std::endl;
-//std::cout << second_image[((i * num_y + j) * num_classes) + s] << std::endl;
-        second_image[((i * num_y + j) * num_classes) + s] /= 2;
+        second_image[((i * num_y + j) * num_classes) + s] *= 0.5f;
         second_image[((i * num_y + j) * num_classes) + s] += 0.5f * first_image[((i * num_y + j) * num_classes) + s];
       }
     }
@@ -841,7 +832,7 @@ int main(int argc, char *argv[]) {
       //    std::cout << "Right " << rightROI << std::endl;
       rightImage = orig_image_mat(rightROI);
 
-      if (do_quads) {
+      if (do_quads && static_cast<float>(sub_image_height) > 1.4 * static_cast<float>(input_height)) {
         sub_image_height = std::max(overlap_pixels + static_cast<int>(static_cast<float>(image_height) / 2.f), input_height);
 //        sub_image_height = std::max(static_cast<int>(static_cast<float>(image_height) * overlap_fraction / 2.f), input_height);
         sub_image_width = static_cast<int>(static_cast<float>(sub_image_height) / input_aspect_ratio);

--- a/tensorflow/cc/inference.cpp
+++ b/tensorflow/cc/inference.cpp
@@ -572,7 +572,8 @@ void add_images(const std::vector<float> &first_image,
     for (auto j = 0; j < num_y; j++) {
       for (auto s = 0; s < num_classes; s++) {
         second_image[((i * num_y + j) * num_classes) + s] *= 0.5f;
-        second_image[((i * num_y + j) * num_classes) + s] += 0.5f * first_image[((i * num_y + j) * num_classes) + s];
+        // Note that TF rows and columns are reversed
+        second_image[((i * num_y + j) * num_classes) + s] += 0.5f * first_image[((j * num_y + i) * num_classes) + s];
       }
     }
   }
@@ -1082,8 +1083,7 @@ int main(int argc, char *argv[]) {
       for (std::size_t ihex = 0; ihex < hex_quads.size(); ++ihex) {
         std::cout << "Adding hex-quad " << ihex << " to sub-images" << std::endl;
         hive_segmentation::add_images(hex_quads[ihex],
-                                      &(float_output_quad_array[static_cast<int>(ihex) * quad_image_height
-                                          * quad_image_width * output_classes]),
+                                      &(float_output_quad_array[static_cast<int>(ihex) * quad_image_height * quad_image_width * output_classes]),
                                       quad_image_height,
                                       quad_image_width,
                                       output_classes);
@@ -1095,19 +1095,19 @@ int main(int argc, char *argv[]) {
         int sub_offset = iquad * 4;
         std::cout << "Merging four quads into quad sub-image " << iquad << std::endl;
 
-      // now have 4x dimensional array of size quad_image_height x quad_image_width x num_classes
-      // ((0 hz 1) vt (2 hz 3)) hz ((4 hz 5) vt (6 hz 7))
-      // (  top    vt  bottom ) hz (  top    vt  bottom )
-      //         left           hz           right
+        // now have 4x dimensional array of size quad_image_height x quad_image_width x num_classes
+        // ((0 hz 1) vt (2 hz 3)) hz ((4 hz 5) vt (6 hz 7))
+        // (  top    vt  bottom ) hz (  top    vt  bottom )
+        //         left           hz           right
 
-      auto merged_top_quad = hive_segmentation::hz_merge(float_output_quad_array,
-                                                         sub_offset + 0,
-                                                         sub_offset + 1,
-                                                         quad_image_height,
-                                                         quad_image_width,
-                                                         output_classes,
-                                                         quad_image_height,
-                                                         leftImage.cols);
+        auto merged_top_quad = hive_segmentation::hz_merge(float_output_quad_array,
+                                                           sub_offset + 0,
+                                                           sub_offset + 1,
+                                                           quad_image_height,
+                                                           quad_image_width,
+                                                           output_classes,
+                                                           quad_image_height,
+                                                           leftImage.cols);
 
         auto merged_bottom_quad = hive_segmentation::hz_merge(float_output_quad_array,
                                                               sub_offset + 2,
@@ -1170,8 +1170,7 @@ int main(int argc, char *argv[]) {
     for (std::size_t iquad = 0; iquad < quad_subs.size(); ++iquad) {
       std::cout << "Adding quad sub-image " << iquad << " to image" << std::endl;
       hive_segmentation::add_images(quad_subs[iquad],
-                                    &(float_output_array[static_cast<int>(iquad) * sub_image_height * sub_image_width
-                                        * output_classes]),
+                                    &(float_output_array[static_cast<int>(iquad) * sub_image_height * sub_image_width * output_classes]),
                                     sub_image_height,
                                     sub_image_width,
                                     output_classes);


### PR DESCRIPTION
Merge branch is a little confusing.  The update includes a switch from TF 2alpha to TF 2.0 and I didn't want the thousands--literally--of other commits confusing things.

The core functionality is to enable another level of decomposition to input images--currently 10, this adds another 32 sub-images.

There are two things I still want to do.  First is pull out the left-right images into a separate vector because we are resizing them along with the 8 quads which is consuming too much memory.

And I will recreate the handling for a perfectly square input image which is currently commented out.